### PR TITLE
0.10.2: apply clippy-suggested cleanups

### DIFF
--- a/biscuiting-lib/Cargo.lock
+++ b/biscuiting-lib/Cargo.lock
@@ -47,18 +47,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "biscuiting-lib"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "imageproc 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1063,7 +1054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
-"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"

--- a/biscuiting-lib/Cargo.toml
+++ b/biscuiting-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "biscuiting-lib"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Mike Moran <mike@houseofmoran.com>"]
 edition = "2018"
 
@@ -15,7 +15,6 @@ wasm-bindgen-test = "0.2"
 web-sys = { version="0.3", features = ['console', 'Window', 'Performance'] }
 js-sys = "0.3"
 url = "2.1"
-base64 = "0.10"
 imageproc = "0.19"
 image = "0.22"
 rand = "0.7"

--- a/biscuiting-lib/src/border/mod.rs
+++ b/biscuiting-lib/src/border/mod.rs
@@ -25,7 +25,7 @@ impl BorderFinder {
                     .map(|(x, y)| vec![x, y])
                     .flatten()
                     .collect::<Vec<u32>>();
-                return Some(flattened_border);
+                Some(flattened_border)
             }
             None => None,
         }


### PR DESCRIPTION
- remove unneeded returns
- extract Default for BiscuitFinder
- replace loop variable `label_id` with iter:
`for label_id in 1..=num_labels` ->
```
for (label_id, bounding_box) in bounding_boxes
                    .iter()
                    .enumerate()
                    .take(num_labels + 1)
                    .skip(1)
```
  (I'm not convinced this last is better
   but I'm gonna run with it)
- remove unneeded crate `base64`